### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ $ npm install --save kelvin-to-celsius
 const kelvinToCelsius = require('kelvin-to-celsius');
 
 kelvinToCelsius(45);
-//=> -223,15
+//=> -228.15
 ```
 
 


### PR DESCRIPTION
`45 K` is `-228.15 °C`, both according to your module and Google. 
